### PR TITLE
feat: add -p/--prompt option to provide additional commit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ NOTE: All common config can be configured via `~/.fastcommit/config.toml`
 - `-gb, --generate-branch`: Generate branch name.
    - `--branch-prefix`: prefix of the generated branch name
 - `-v, --verbosity <VERBOSITY>`: Set the detail level of the commit message. Acceptable values are `verbose` (detailed), `normal`, or `quiet` (concise). The default is `quiet`.
+- `-p, --prompt <PROMPT>`: Additional prompt to help AI understand the commit context.
 - `-h, --help`: Print help information.
 - `-V, --version`: Print version information.
 
@@ -53,6 +54,12 @@ NOTE: All common config can be configured via `~/.fastcommit/config.toml`
 
    ```bash
    fastcommit -d changes.diff -v verbose
+   ```
+
+4. Provide additional context to help AI understand the commit:
+
+   ```bash
+   fastcommit -d changes.diff -p "Fixed login page styling issues, especially button alignment"
    ```
 
 ## Contributing

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,7 @@ NOTE: All common config can be configured via `~/.fastcommit/config.toml`
 - `-gb, --generate-branch`: 模式：生成分支名
    - `--branch-prefix`: 生成的分支名的前缀 
 - `-v, --verbosity <VERBOSITY>`: 设置提交信息的详细级别。可选值为 `verbose`（详细）、`normal`（正常）或 `quiet`（简洁）。 默认为 `quiet`。
+- `-p, --prompt <PROMPT>`: 额外的提示信息，帮助 AI 理解提交上下文。
 - `-h, --help`: 打印帮助信息。
 - `-V, --version`: 打印版本信息。
 
@@ -51,6 +52,12 @@ NOTE: All common config can be configured via `~/.fastcommit/config.toml`
 
    ```bash
    fastcommit -d changes.diff -v verbose
+   ```
+
+4. 提供额外上下文帮助 AI 理解提交：
+
+   ```bash
+   fastcommit -d changes.diff -p "修复了登录页面的样式问题，特别是按钮对齐"
    ```
 
 ## 贡献

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,4 +26,7 @@ pub struct Args {
 
     #[clap(long, help = "Override branch prefix (default from config)")]
     pub branch_prefix: Option<String>,
+
+    #[clap(short, long, help = "Additional prompt to help AI understand the commit context")]
+    pub prompt: Option<String>,
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,8 @@ pub const DEFAULT_PROMPT_TEMPLATE: &str = r#"
 - 使用{{language}}编写
 - 详细程度：{{verbosity_level}}
 
+{{user_description}}
+
 # 什么是约定式提交规范？
 
 约定式提交 1.0.0
@@ -73,6 +75,7 @@ pub enum PromptTemplateReplaceLabel {
     VerbosityLevel,
     ConventionalCommit,
     Diff,
+    UserDescription,
 }
 
 impl PromptTemplateReplaceLabel {
@@ -82,6 +85,7 @@ impl PromptTemplateReplaceLabel {
             PromptTemplateReplaceLabel::VerbosityLevel => "{{verbosity_level}}",
             PromptTemplateReplaceLabel::ConventionalCommit => "{{conventional_commit}}",
             PromptTemplateReplaceLabel::Diff => "{{diff}}",
+            PromptTemplateReplaceLabel::UserDescription => "{{user_description}}",
         }
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -11,13 +11,22 @@ use crate::constants::{
 };
 use crate::template_engine::{render_template, TemplateContext};
 
-async fn generate_commit_message(diff: &str, config: &config::Config) -> anyhow::Result<String> {
+async fn generate_commit_message(
+    diff: &str,
+    config: &config::Config,
+    user_description: Option<&str>,
+) -> anyhow::Result<String> {
     let auth = Auth::new(config.api_key.as_str());
 
     let openai = OpenAI::new(auth, &config.api_base());
 
-    let template_ctx =
-        TemplateContext::new(config.conventional, config.language, config.verbosity, diff);
+    let template_ctx = TemplateContext::new(
+        config.conventional,
+        config.language,
+        config.verbosity,
+        diff,
+        user_description,
+    );
 
     let messages = vec![
         Message {
@@ -123,7 +132,7 @@ fn get_diff(diff_file: Option<&str>) -> anyhow::Result<String> {
 
 pub async fn generate(args: &cli::Args, config: &Config) -> anyhow::Result<String> {
     let diff = get_diff(args.diff_file.as_deref())?;
-    let message = generate_commit_message(&diff, config).await?;
+    let message = generate_commit_message(&diff, config, args.prompt.as_deref()).await?;
     Ok(message)
 }
 

--- a/src/template_engine.rs
+++ b/src/template_engine.rs
@@ -8,6 +8,7 @@ pub struct TemplateContext<'a> {
     pub language: CommitLanguage,
     pub verbosity: Verbosity,
     pub diff_content: &'a str,
+    pub user_description: Option<&'a str>,
 }
 
 impl<'a> TemplateContext<'a> {
@@ -16,12 +17,14 @@ impl<'a> TemplateContext<'a> {
         language: CommitLanguage,
         verbosity: Verbosity,
         diff_content: &'a str,
+        user_description: Option<&'a str>,
     ) -> Self {
         Self {
             conventional,
             language,
             verbosity,
             diff_content,
+            user_description,
         }
     }
 }
@@ -43,6 +46,10 @@ pub fn render_template(template: &str, context: TemplateContext) -> anyhow::Resu
         .replace(
             PromptTemplateReplaceLabel::Diff.get_label(),
             context.diff_content,
+        )
+        .replace(
+            PromptTemplateReplaceLabel::UserDescription.get_label(),
+            context.user_description.unwrap_or(""),
         );
 
     Ok(rendered)


### PR DESCRIPTION
# Add Custom Prompt Support

## Summary
Adds `--prompt`/`-p` CLI option allowing users to provide additional context for AI-generated commit messages.

## Changes
- Added `-p, --prompt <PROMPT>` CLI argument
- Extended template engine to support user descriptions
- Updated prompt template to incorporate user context
- Updated documentation (EN/CN) with usage examples

## Usage
```bash
fastcommit -p "Fixed login styling issues"
```

## Impact
Improves commit message accuracy by letting users provide context without replacing the core prompt logic.

## Disclaimer
The content of this PR (including code and descriptions) was generated by a LLM (Kimi-K2).