### PR TITLE
fix(generate): 修复推理模型无法生成分支名的问题

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -187,7 +187,7 @@ async fn generate_branch_name_with_ai(
         n: None,
         stream: Some(false),
         stop: Some(STOP_WORDS.to_owned()),
-        max_tokens: Some(40),
+        max_tokens: Some(DEFAULT_MAX_TOKENS as i32),
         presence_penalty: None,
         frequency_penalty: None,
         logit_bias: None,


### PR DESCRIPTION
将硬编码的max_tokens值40替换为常量DEFAULT_MAX_TOKENS，以解决推理模型在生成分支名时因token限制不足而失败的问题。