### PR TITLE
fix(generate): 移除stop words并改进消息提取逻辑

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "fastcommit"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastcommit"
-version = "0.2.1"
+version = "0.2.2"
 description = "AI-based command line tool to quickly generate standardized commit messages."
 edition = "2021"
 authors = ["longjin <fslongjin@vip.qq.com>"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can install `fastcommit` using the following method:
 
 ```bash
 # Install using cargo
-cargo install --git  https://github.com/fslongjin/fastcommit --tag v0.2.1
+cargo install --git  https://github.com/fslongjin/fastcommit --tag v0.2.2
 ```
 
 ## Usage

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,7 +8,7 @@
 
 ```bash
 # 使用 cargo 安装
-cargo install --git  https://github.com/fslongjin/fastcommit --tag v0.2.1
+cargo install --git  https://github.com/fslongjin/fastcommit --tag v0.2.2
 ```
 
 ## 使用

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -90,11 +90,7 @@ impl PromptTemplateReplaceLabel {
     }
 }
 
-lazy_static! {
-    pub static ref STOP_WORDS: Vec<String> = vec![String::from("</aicommit>")];
-}
-
-pub const DEFAULT_MAX_TOKENS: u32 = 2048;
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 pub const BRANCH_NAME_PROMPT: &str = r#"
 # 角色

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 use clap::Parser;
 use log::error;
 
-#[macro_use]
-extern crate lazy_static;
-
 mod cli;
 mod config;
 mod constants;


### PR DESCRIPTION
  - 移除STOP_WORDS常量以避免AI思考过程中的干扰
- 将DEFAULT_MAX_TOKENS从2048增加到4096以支持更长的响应
- 重写extract_aicommit_message函数，改进提取逻辑以处理多个<aicommit>块
- 移除对lazy_static的依赖